### PR TITLE
Fix bufferSizeInSeconds Not Affecting preferredForwardBufferDuration

### DIFF
--- a/Sources/Player.swift
+++ b/Sources/Player.swift
@@ -262,7 +262,11 @@ open class Player: UIViewController {
     }
 
     /// Playback buffering size in seconds.
-    open var bufferSizeInSeconds: Double = 10
+    open var bufferSizeInSeconds: Double = 10 {
+        didSet {
+            self._playerItem?.preferredForwardBufferDuration = self.bufferSizeInSeconds
+        }
+    }
 
     /// Playback is not automatically triggered from state changes when true.
     open var playbackEdgeTriggered: Bool = true
@@ -684,6 +688,8 @@ extension Player {
         if #available(iOS 11.0, tvOS 11.0, *) {
             self._playerItem?.preferredMaximumResolution = self._preferredMaximumResolution
         }
+
+        self._playerItem?.preferredForwardBufferDuration = self.bufferSizeInSeconds
 
         if let seek = self._seekTimeRequested, self._playerItem != nil {
             self._seekTimeRequested = nil


### PR DESCRIPTION
In the case of a playback stall (as shown below), the interrupted player will wait for the buffer to catch up before resuming playback. The "safe" amount of buffer headroom is supposed to be configurable.

```
{
  "transportType" : "HTTP Progressive Download",
  "mediaType" : "HTTP Progressive Download",
  "BundleID" : "RedGift",
  "name" : "MEDIA_PLAYBACK_STALL",
  "interfaceType" : "Loopback"
}
```

Previously, `bufferSizeInSeconds` had no effect on `preferredForwardBufferDuration`, causing the player to wait a long time for a large, Apple-configured buffer headroom value. It should instead adhere to the `bufferSizeInSeconds` configuration in the `Player` class. This PR fixes the issue.